### PR TITLE
スタッフ割り当て数を最後のカラムから競技数の右のカラムへ移動

### DIFF
--- a/auto_grouping/cube-comp-grouping.ipynb
+++ b/auto_grouping/cube-comp-grouping.ipynb
@@ -171,6 +171,10 @@
     "#  グループ分けに使うカラムの追加\n",
     "df = df.assign(staffable=0).assign(**{f\"{event}_rank\": 999999 for event in events})\n",
     "df[\"event_count\"] = df[list(events)].sum(axis=1).astype(int)\n",
+    "\n",
+    "# スタッフ割り当て数と競技数は横並びのほうが見やすいので、この場所でカラムを宣言しておく\n",
+    "df = df.assign(staff_count=0)\n",
+    "\n",
     "for wcaid in df[\"WCA ID\"][df[\"WCA ID\"].notnull()]:\n",
     "    staffable = 0 if wcaid in staff_blacklist else 1\n",
     "    df.loc[df[\"WCA ID\"] == wcaid, \"staffable\"] = staffable\n",
@@ -224,7 +228,6 @@
    "outputs": [],
    "source": [
     "# スタッフ割当\n",
-    "df = df.assign(staff_count=0)\n",
     "for (event, gnames) in group_names.items():\n",
     "    for (i_group, group_column) in enumerate(gnames):\n",
     "        staffable_df = df[df[\"staffable\"] == 1][df[group_column]  == 0]\n",


### PR DESCRIPTION
参加する競技数とスタッフ割り当て数は横並びのほうが見やすいので、スタッフ割り当て数を最後のカラムから競技数の右のカラムへ移動した。