### PR TITLE
ジャッジの人数が足りなかった場合に、可能な限り割り当てをしつつ処理を続行するオプションを追加

### DIFF
--- a/auto_grouping/cube-comp-grouping.ipynb
+++ b/auto_grouping/cube-comp-grouping.ipynb
@@ -94,6 +94,12 @@
     "# 間違った種目名にしていないか確認\n",
     "assert all([ (event in ALL_EVENTS) for event in num_staffs.keys() ]), 'num_staffsの種目名に誤りがあります。'\n",
     "\n",
+    "# スタッフの人数が足りなかった場合に処理を続行するかどうか\n",
+    "# Trueの場合、可能な限りの人数をジャッジに割り当てつつ、処理を続行\n",
+    "# Falseの場合、エラーを出力して停止。\n",
+    "# 問題がある割り当てに気付けるように基本的にはFalseにしておいて、問題が起こったら一時的にTrueにしてから手作業で調整\n",
+    "continue_when_judges_run_out = False\n",
+    "\n",
     "# スタッフを割り当てない人をここにリストアップする (運営スタッフ , 子供, 外国人等)\n",
     "# 初参加の人には自動で割り当てないようにするので、含める必要はない\n",
     "staff_blacklist = [\"2016MANN01\", \"2017FARN01\", \"2017FARN02\", \"2006NISH01\", \"2017SHIK01\", \"2016XIAN08\", \"2018YAMA02\", \"2012YOSH02\", \"2013KIMD01\", \"2018PILE01\", \"2017HIKI01\", \"2017OGAT01\", \"2016GABA02\", \"2018YOSH03\", \"2017FURU04\", \"2017TAKE04\", \"2017TAKE05\", \"2014ASHI01\", \"2018KITA01\", \"2015NUPU01\", \"2018KURO04\", \"2012JIAN06\", \"2010TANA02\", \"2018NOJI01\", \"2005SUSE01\", \"2017ALIB02\", \"2010SICH01\"] "
@@ -229,9 +235,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# スタッフ割当\n",
@@ -258,14 +262,21 @@
     "            staff_candidates = staffable_df[staffable_df[event] == 0].sort_values([\"staff_count\", \"staff_count-event_count\"] + [f\"{e}_rank\" for e in events]).index\n",
     "\n",
     "        for (role, num_needed) in num_staffs[event].items():\n",
-    "            if len(staff_candidates) >= num_needed:\n",
-    "                staff_ids = staff_candidates[:num_needed]\n",
-    "                staff_candidates = staff_candidates[num_needed:]\n",
-    "                for staff in staff_ids:\n",
-    "                    df.loc[staff, group_column] = role\n",
-    "                    df.loc[staff, \"staff_count\"] += 1\n",
-    "            else:\n",
-    "                raise Exception(\"スタッフ足りなくて割当無理でした\")"
+    "            error_msg = \"{}でスタッフ足りなくて割当無理でした: {} < {}\".format(group_column, len(staff_candidates), num_needed)\n",
+    "            if len(staff_candidates) < num_needed and (not continue_when_judges_run_out):\n",
+    "                raise Exception(error_msg)\n",
+    "            \n",
+    "            # 後ろの条件はなくても挙動は変わらないが、読みやすいように明示しておいた\n",
+    "            if len(staff_candidates) < num_needed and continue_when_judges_run_out:\n",
+    "                # 可能な人員を最大限割り当てて処理を続行\n",
+    "                print(error_msg)\n",
+    "                num_needed = len(staff_candidates)\n",
+    "            \n",
+    "            staff_ids = staff_candidates[:num_needed]\n",
+    "            staff_candidates = staff_candidates[num_needed:]\n",
+    "            for staff in staff_ids:\n",
+    "                df.loc[staff, group_column] = role\n",
+    "                df.loc[staff, \"staff_count\"] += 1"
    ]
   },
   {


### PR DESCRIPTION
これまでは、スタッフの人数が足りなかった場合、実行を停止していた。
しかし、実際に運用した場合に、「エラーで停止してしまうのではなく、できるところまで割り当てておいて、その後に手作業で調整したい」という要望があった。

そのため、`continue_when_judges`という変数を追加し、ジャッジの人数が足りなかった場合に、可能な限り割り当てをしつつ処理を続行できるようにした。

`continue_when_judges = True`のときは、
```
333_Aでスタッフ足りなくて割当無理でした: 11 < 12
```
のようなメッセージを表示する。